### PR TITLE
TransactionHash + ListExtension.equalsContent

### DIFF
--- a/base/lib/base/models/key.dart
+++ b/base/lib/base/models/key.dart
@@ -1,6 +1,5 @@
 import 'dart:typed_data';
 
-import 'package:collection/collection.dart';
 import 'package:kinny/base/tools/base58.dart';
 import 'package:kinny/base/tools/extensions.dart';
 import 'package:kinny/stellarfork/key_pair.dart';
@@ -23,7 +22,7 @@ abstract class Key {
       identical(this, other) ||
       other is Key &&
           runtimeType == other.runtimeType &&
-          ListEquality().equals(value, other.value);
+          value.equalsContent(other.value);
 
   @override
   int get hashCode => value.computeHashCode();

--- a/base/lib/base/models/kin_account.dart
+++ b/base/lib/base/models/kin_account.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:kinny/base/tools/base58.dart';
+import 'package:kinny/base/tools/extensions.dart';
 import 'package:kinny/stellarfork/key_pair.dart';
 
 import 'key.dart';
@@ -17,10 +18,12 @@ class KinAccountId {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is KinAccountId && runtimeType == other.runtimeType && value == other.value;
+      other is KinAccountId &&
+          runtimeType == other.runtimeType &&
+          value.equalsContent(other.value);
 
   @override
-  int get hashCode => value.hashCode;
+  int get hashCode => value.computeHashCode();
 
   String toString() {
     return "Id(value=${stellarBase32Encode()}, b58=${base58Encode()})";
@@ -40,7 +43,8 @@ class KinAccountStatus {
 }
 
 class KinAccountStatusUnregistered extends KinAccountStatus {
-  static final KinAccountStatusUnregistered instance = KinAccountStatusUnregistered._();
+  static final KinAccountStatusUnregistered instance =
+      KinAccountStatusUnregistered._();
 
   KinAccountStatusUnregistered._() : super._(0);
 
@@ -61,7 +65,10 @@ class KinAccount {
   final KinAccountStatus status;
 
   KinAccount(this.key,
-      {KinAccountId id, List<PublicKey> tokenAccounts, KinBalance balance, KinAccountStatus status})
+      {KinAccountId id,
+      List<PublicKey> tokenAccounts,
+      KinBalance balance,
+      KinAccountStatus status})
       : id = id ?? KinAccountId(key.asPublicKey().value),
         tokenAccounts = tokenAccounts ?? <PublicKey>[],
         balance = balance ?? KinBalance(),

--- a/base/lib/base/models/solana/fixed_byte_array.dart
+++ b/base/lib/base/models/solana/fixed_byte_array.dart
@@ -1,8 +1,7 @@
 import 'dart:typed_data';
 import 'dart:ui';
 
-import 'package:collection/collection.dart';
-import 'package:kin_sdk/base/tools/byte_utils.dart';
+import 'package:kinny/base/tools/byte_utils.dart';
 import 'package:kinny/base/tools/extensions.dart';
 
 abstract class FixedByteArray {
@@ -30,7 +29,7 @@ abstract class FixedByteArray {
     ///kotlin: if (javaClass != other?.javaClass) return false
     if (this.runtimeType != other?.runtimeType) return false;
     if (other is FixedByteArray) {
-      if (!ListEquality().equals(byteArray, other.byteArray)) return false;
+      if (!byteArray.equalsContent(other.byteArray)) return false;
     } else {
       return false;
     }

--- a/base/lib/base/models/solana/instruction.dart
+++ b/base/lib/base/models/solana/instruction.dart
@@ -1,10 +1,9 @@
 import 'dart:typed_data';
 import 'dart:ui';
 
-import 'package:collection/collection.dart';
 import 'package:kinny/base/models/key.dart';
-import 'package:meta/meta.dart';
 import 'package:kinny/base/tools/extensions.dart';
+import 'package:meta/meta.dart';
 
 /// AccountMeta represents the account information required
 /// for building transactions.
@@ -95,8 +94,8 @@ class Instruction {
     this.data,
   );
 
-  static Instruction newInstruction(
-      PublicKey program, Uint8List data, [List<AccountMeta> accounts]) {
+  static Instruction newInstruction(PublicKey program, Uint8List data,
+      [List<AccountMeta> accounts]) {
     return Instruction(program, accounts, data);
   }
 
@@ -106,8 +105,8 @@ class Instruction {
 //    if (other is! Instruction) return false;
     if (other is Instruction) {
       if (program != other.program) return false;
-      if (accounts != other.accounts) return false;
-      if (!ListEquality().equals(data, other.data)) return false;
+      if (!accounts.equalsContent(other.accounts)) return false;
+      if (!data.equalsContent(other.data)) return false;
     } else {
       return false;
     }
@@ -140,8 +139,8 @@ class CompiledInstruction {
 //    if (other is! CompiledInstruction) return false;
     if (other is CompiledInstruction) {
       if (programIndex.toInt() != other.programIndex.toInt()) return false;
-      if (!ListEquality().equals(accounts, other.accounts)) return false;
-      if (!ListEquality().equals(data, other.data)) return false;
+      if (!accounts.equalsContent(other.accounts)) return false;
+      if (!data.equalsContent(other.data)) return false;
     } else {
       return false;
     }

--- a/base/lib/base/models/solana/transaction.dart
+++ b/base/lib/base/models/solana/transaction.dart
@@ -100,7 +100,7 @@ class Transaction {
     //   2. Writable accounts before read-only accounts.
     //   3. Programs last
     final List<AccountMeta> uniqueAccounts =
-    accounts.filterUnique().toList().quickSort();
+    accounts.filterUnique().toList()..sort();
 
     final header = Header(
       numSignatures: uniqueAccounts
@@ -136,7 +136,7 @@ class Transaction {
 
   static int _indexOf(List<PublicKey> slice, PublicKey item) {
     slice.asMap().forEach((i, publicKey) {
-      if (ListEquality().equals(publicKey.value, item.value)) {
+      if (publicKey.value.equalsContent(item.value)) {
         return i;
       }
     });
@@ -188,8 +188,7 @@ extension on List<AccountMeta> {
     for (var element in this) {
       for (int i = 0; i < filtered.length; i++) {
         final accountMeta = filtered[i];
-        if (ListEquality().equals(
-            element.publicKey.value, accountMeta.publicKey.value)) {
+        if (element.publicKey.value.equalsContent(accountMeta.publicKey.value)) {
           // Promote the existing account to writable if applicable
           if (element.isSigner)
             filtered[i] = filtered[i].copyWith(isSigner: true);

--- a/base/lib/base/models/transaction_hash.dart
+++ b/base/lib/base/models/transaction_hash.dart
@@ -1,1 +1,26 @@
-//Placeholder
+import 'dart:typed_data';
+
+import 'package:kinny/base/tools/extensions.dart';
+import 'package:kinny/base/tools/hex.dart';
+
+class TransactionHash {
+  final Uint8List rawValue;
+
+  TransactionHash(this.rawValue);
+
+  TransactionHash.fromHashString(String transactionHashString)
+      : this(HexDecoder().convert(transactionHashString));
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TransactionHash &&
+          runtimeType == other.runtimeType &&
+          rawValue.equalsContent(other.rawValue);
+
+  @override
+  int get hashCode => rawValue.computeHashCode();
+
+  @override
+  String toString() => HexEncoder().convert(rawValue);
+}

--- a/base/lib/base/tools/extensions.dart
+++ b/base/lib/base/tools/extensions.dart
@@ -1,5 +1,7 @@
 import 'dart:typed_data';
 
+import 'package:collection/collection.dart' show ListEquality;
+
 extension IntExtension on int {
   ByteData toByte() => ByteData(1)..setInt8(0, this);
 }
@@ -15,12 +17,10 @@ extension Uint8ListExtension on Uint8List {
   ByteData toByte() => ByteData.sublistView(this);
 }
 
-extension ListIntExtension on List<int> {
-  int computeHashCode() {
-    var h = 0;
-    for (var e in this) {
-      h = 31 * h + e;
-    }
-    return h;
-  }
+extension ListExtension<T> on List<T> {
+  static const ListEquality _listEquality = ListEquality();
+
+  int computeHashCode() => _listEquality.hash(this);
+
+  bool equalsContent(List<T> other) => _listEquality.equals(this, other);
 }

--- a/base/lib/base/tools/hex.dart
+++ b/base/lib/base/tools/hex.dart
@@ -1,0 +1,83 @@
+//
+// Based into:
+// `dart-hex` (https://github.com/stevenroose/dart-hex) [The MIT License (MIT)]
+//
+
+import "dart:convert";
+import "dart:typed_data";
+
+const String _ALPHABET = '0123456789abcdef';
+
+/// An instance of the default implementation of the [HexCodec].
+const HEX = const HexCodec();
+
+/// A codec for encoding and decoding byte arrays to and from
+/// hexadecimal strings.
+class HexCodec extends Codec<List<int>, String> {
+  const HexCodec();
+
+  @override
+  Converter<List<int>, String> get encoder => const HexEncoder();
+
+  @override
+  Converter<String, Uint8List> get decoder => const HexDecoder();
+}
+
+/// A converter to encode byte arrays into hexadecimal strings.
+class HexEncoder extends Converter<List<int>, String> {
+  /// If true, the encoder will encode into uppercase hexadecimal strings.
+  final bool upperCase;
+
+  const HexEncoder({this.upperCase: false});
+
+  @override
+  String convert(List<int> bytes) {
+    var buffer = new StringBuffer();
+    for (int part in bytes) {
+      if (part & 0xff != part) {
+        throw new FormatException('Non-byte integer detected');
+      }
+
+      var h = part.toRadixString(16).padLeft(2, '0');
+      buffer.write(h);
+    }
+
+    if (upperCase) {
+      return buffer.toString().toUpperCase();
+    } else {
+      return buffer.toString();
+    }
+  }
+}
+
+/// A converter to decode hexadecimal strings into byte arrays.
+class HexDecoder extends Converter<String, Uint8List> {
+  const HexDecoder();
+
+  static final _regexpBlankSpace = RegExp(r'\s+');
+
+  @override
+  Uint8List convert(String hex) {
+    var str = hex.replaceAll(_regexpBlankSpace, '');
+    str = str.toLowerCase();
+    if (str.length % 2 != 0) {
+      str = '0$str';
+    }
+
+    var size = str.length ~/ 2;
+    var result = Uint8List(size);
+
+    for (int i = 1; i < size; i += 2) {
+      var h0 = str[i - 1];
+      var h1 = str[i];
+      var firstDigit = _ALPHABET.indexOf(h0);
+      var secondDigit = _ALPHABET.indexOf(h1);
+      if (firstDigit == -1 || secondDigit == -1) {
+        throw new FormatException("Non-hex character detected in $hex");
+      }
+      result[i] = (firstDigit << 4) + secondDigit;
+    }
+
+    return result;
+  }
+}


### PR DESCRIPTION
- Implemented `transaction.dart`: TransactionHash
- Added `hex.dart`: `HexCodec`, `HexEncoder`, `HexDecoder`.
- Changed `ListExtension` to be applied to any `List`.
  - Added `equalsContent`: to compare the content with other `List`.
  - `computeHashCode` now uses `ListEquality` to keep Dart standard behavior.
- Removed use of `ListEquality`, to use `ListExtension`:
  - key.dart
  - kin_account.dart
  - solana/
    - fixed_byte_array.dart
    - instruction.dart
    - transaction.dart