### PR TITLE
- Mark old `kin_services.dart` as deprecated.

### DIFF
--- a/base/lib/base/kin_account_context.dart
+++ b/base/lib/base/kin_account_context.dart
@@ -3,7 +3,7 @@ import 'package:kin_base/base/models/kin_balance.dart';
 import 'package:kin_base/base/stellar/models/kin_transaction.dart';
 import 'package:kin_base/base/tools/kin_logger.dart';
 import 'package:kin_base/base/tools/observers.dart';
-import 'package:kin_base/services/kin_services.dart';
+import 'package:kin_base/base/network/services/kin_service.dart';
 import 'package:kin_base/stellarfork/key_pair.dart';
 import 'package:kin_base/stellarfork/xdr/xdr_signing.dart';
 
@@ -554,7 +554,7 @@ class KinAccountContextImpl extends KinAccountContextBase with KinAccountContext
   }
 
   Future<KinAccount> _registerAccount(KinAccount account) async {
-    var serviceAccount = await service.createAccount( accountId: account.id, privateKey: account.key as PrivateKey) ;
+    var serviceAccount = await service.createAccount( account.id, account.key as PrivateKey ) ;
     var accountToStore = account.merge(serviceAccount);
 
     if (!storage.updateAccount(accountToStore)) {

--- a/base/lib/base/kin_environment.dart
+++ b/base/lib/base/kin_environment.dart
@@ -5,11 +5,14 @@ import 'package:kin_base/base/repository/app_info_repository.dart';
 import 'package:kin_base/base/repository/invoice_repository.dart';
 import 'package:kin_base/base/storage/storage.dart';
 import 'package:kin_base/base/tools/observers.dart';
-import 'package:kin_base/services/kin_services.dart';
+
+import 'package:kin_base/base/network/services/kin_service.dart';
+
 
 import 'models/key.dart';
 import 'models/kin_account.dart';
 import 'network/services/app_info_providers.dart';
+import 'network/services/kin_service_impl.dart';
 import 'stellar/models/api_config.dart';
 import 'stellar/models/network_environment.dart';
 import 'tools/executor_service.dart';
@@ -111,6 +114,8 @@ class KinEnvironmentAgora extends KinEnvironment {
     if (appInfoProvider == null) throw KinEnvironmentBuilderException("Must provide an ApplicationDelegate!");
 
     managedChannel ??= _asManagedChannel( _agoraApiConfig(networkEnvironment) , logger, 4);
+
+    service ??= KinServiceImpl();
 
     if (storage == null) {
       storage = storageBuilder(networkEnvironment: networkEnvironment) ;

--- a/base/lib/base/network/services/kin_service.dart
+++ b/base/lib/base/network/services/kin_service.dart
@@ -55,19 +55,7 @@ abstract class KinService {
     invalidateBlockhashCache() ;
 }
 
-class KinServiceOrder {
-    final int value;
-
-    KinServiceOrder(this.value);
-}
-
-class Ascending extends KinServiceOrder {
-  Ascending() : super(0);
-}
-
-class Descending extends KinServiceOrder {
-  Descending() : super(1);
-}
+enum KinServiceOrder { ascending, descending }
 
 class FatalError extends StateError {
     final Error reason ;

--- a/base/lib/base/network/services/kin_service_impl.dart
+++ b/base/lib/base/network/services/kin_service_impl.dart
@@ -1,1 +1,30 @@
-//Placeholder
+
+
+import 'package:kin_base/base/network/api/kin_transaction_api.dart';
+import 'package:kin_base/base/stellar/models/network_environment.dart';
+import 'package:kin_base/base/tools/kin_logger.dart';
+
+import 'kin_service.dart';
+
+class KinServiceImpl extends KinService {
+
+  final NetworkEnvironment networkEnvironment ;
+  final NetworkOperationsHandler networkOperationsHandler ;
+  final KinAccountApi accountApi ;
+  final KinTransactionApi transactionApi ;
+  final KinStreamingApi streamingApi ;
+  final KinAccountCreationApi accountCreationApi ;
+  final KinTransactionWhitelistingApi transactionWhitelistingApi ;
+  final KinLoggerFactory logger;
+
+  KinServiceImpl(
+
+      this.networkEnvironment,
+      this.networkOperationsHandler,
+      this.accountApi,
+      this.transactionApi,
+      this.streamingApi,
+      this.accountCreationApi,
+      this.transactionWhitelistingApi,
+      this.logger);
+}

--- a/base/lib/base/network/services/kin_service_impl_v4.dart
+++ b/base/lib/base/network/services/kin_service_impl_v4.dart
@@ -1,1 +1,28 @@
-//Placeholder
+
+
+import 'package:kin_base/base/network/api/kin_transaction_api.dart';
+import 'package:kin_base/base/stellar/models/network_environment.dart';
+import 'package:kin_base/base/tools/kin_logger.dart';
+
+import 'kin_service.dart';
+
+class KinServiceImplV4 extends KinService {
+
+  final NetworkEnvironment networkEnvironment ;
+  final NetworkOperationsHandler networkOperationsHandler ;
+  final KinAccountApi accountApi ;
+  final KinTransactionApiV4 transactionApi ;
+  final KinStreamingApiV4 streamingApi ;
+  final KinAccountCreationApiV4 accountCreationApi ;
+  final KinLoggerFactory logger;
+
+  KinServiceImplV4(
+      this.networkEnvironment,
+      this.networkOperationsHandler,
+      this.accountApi,
+      this.transactionApi,
+      this.streamingApi,
+      this.accountCreationApi,
+      this.transactionWhitelistingApi,
+      this.logger);
+}

--- a/base/lib/services/kin_services.dart
+++ b/base/lib/services/kin_services.dart
@@ -16,6 +16,12 @@ import 'package:kin_base/services/transaction/transaction_service.dart';
 import 'package:kin_base/base/network/api/agora/proto_to_model_v4.dart';
 
 /// Services aggregator for the all the operations possible on the Kin blockchain
+///
+/// DEPRECATED!
+/// SHOULD IMPORT:
+/// import 'package:kin_base/base/network/services/kin_service.dart';
+///
+@deprecated
 class KinService {
   AccountService _accountService;
   TransactionService _transactionService;


### PR DESCRIPTION
- `kin_environment.dart` using new `kin_service.dart`.
- `kin_account_context.dart` using new `kin_service.dart`.
- Skeleton of `kin_service_impl.dart` and `kin_service_impl_v4.dart`.